### PR TITLE
add messages to ok call in createDeployment

### DIFF
--- a/scripts/src/createDeployment.ts
+++ b/scripts/src/createDeployment.ts
@@ -242,13 +242,16 @@ export const createDeployment = async ({
 		return { url };
 	} else {
 		const host = HOSTS[environment];
-		ok(host);
+		ok(host, "The cloudflare host couldn't be determined");
 		const pagesProject = PAGES_PROJECTS[environment][trigger];
-		ok(pagesProject);
+		ok(pagesProject, "The pages project couldn't be determined");
 
 		let id: string;
 		if (trigger !== Trigger.DirectUpload) {
-			ok(pagesProject.GIT_REPO);
+			ok(
+				pagesProject.GIT_REPO,
+				"The pages project github repo couldn't be determined"
+			);
 
 			logger.log(`Configuring ${pagesProject.GIT_REPO} remote, and pushing...`);
 			await shellac.in(directory)`
@@ -270,6 +273,7 @@ export const createDeployment = async ({
 				},
 			});
 
+			console.log(`\x1b[31m Aaaaaaaaaaa \x1b[0m`);
 			logger.log("Creating Deploy Hook...");
 			let deployHookCreationResponse: Response;
 			let deployHookCreationResponseText: string;
@@ -322,7 +326,7 @@ export const createDeployment = async ({
 							},
 						}
 					);
-					ok(deployHookDeletionResponse.ok);
+					ok(deployHookDeletionResponse.ok, "Deploy hook deletion failed");
 					logger.info("Done.");
 				},
 			});
@@ -359,7 +363,7 @@ export const createDeployment = async ({
 					deployHookResponseText
 				) as DeployHookResponse;
 
-				ok(result.id);
+				ok(result.id, "Missing id in deploy hook response");
 				id = result.id;
 			} catch {
 				throw await transformResponseIntoError(
@@ -416,8 +420,8 @@ export const createDeployment = async ({
 						result: { url, latest_stage: latestStage },
 					} = JSON.parse(deploymentResponseText) as DeploymentResponse;
 
-					ok(url);
-					ok(latestStage.status);
+					ok(url, "Invalid deployment url");
+					ok(latestStage.status, "Invalid deployment response status");
 
 					if (
 						latestStage.name === "deploy" &&
@@ -492,7 +496,10 @@ export const createDeployment = async ({
 		fixtureConfig: FixtureConfig;
 		featuresConfig: FeaturesConfig;
 	}) {
-		ok([Environment.Production, Environment.Staging].includes(environment));
+		ok(
+			[Environment.Production, Environment.Staging].includes(environment),
+			"Wrong environment specified"
+		);
 
 		logger.log("Configuring project...");
 		logger.info("Getting initial project state...");

--- a/scripts/src/createDeployment.ts
+++ b/scripts/src/createDeployment.ts
@@ -242,15 +242,15 @@ export const createDeployment = async ({
 		return { url };
 	} else {
 		const host = HOSTS[environment];
-		ok(host, "The cloudflare host couldn't be determined");
+		ok(host, "The Cloudflare host couldn't be determined");
 		const pagesProject = PAGES_PROJECTS[environment][trigger];
-		ok(pagesProject, "The pages project couldn't be determined");
+		ok(pagesProject, "The Pages project couldn't be determined");
 
 		let id: string;
 		if (trigger !== Trigger.DirectUpload) {
 			ok(
 				pagesProject.GIT_REPO,
-				"The pages project github repo couldn't be determined"
+				"The Pages project's Git repo couldn't be determined"
 			);
 
 			logger.log(`Configuring ${pagesProject.GIT_REPO} remote, and pushing...`);
@@ -273,7 +273,6 @@ export const createDeployment = async ({
 				},
 			});
 
-			console.log(`\x1b[31m Aaaaaaaaaaa \x1b[0m`);
 			logger.log("Creating Deploy Hook...");
 			let deployHookCreationResponse: Response;
 			let deployHookCreationResponseText: string;
@@ -326,7 +325,7 @@ export const createDeployment = async ({
 							},
 						}
 					);
-					ok(deployHookDeletionResponse.ok, "Deploy hook deletion failed");
+					ok(deployHookDeletionResponse.ok, "Deploy Hook deletion failed");
 					logger.info("Done.");
 				},
 			});
@@ -363,7 +362,7 @@ export const createDeployment = async ({
 					deployHookResponseText
 				) as DeployHookResponse;
 
-				ok(result.id, "Missing id in deploy hook response");
+				ok(result.id, "Missing id in Deploy Hook response");
 				id = result.id;
 			} catch {
 				throw await transformResponseIntoError(
@@ -498,7 +497,7 @@ export const createDeployment = async ({
 	}) {
 		ok(
 			[Environment.Production, Environment.Staging].includes(environment),
-			"Wrong environment specified"
+			"Invalid environment specified"
 		);
 
 		logger.log("Configuring project...");


### PR DESCRIPTION
Locally I forgot to add `--environment=local` and I kept getting this unhelpful error:
![Screenshot 2023-08-11 at 22 28 17](https://github.com/GregBrimble/pages-e2e-tests/assets/61631103/51749a58-4bf2-4ee6-8a8c-508b592d7e1f)

It took me quite a while to figure out what the problem is since debugging and stepping through the code for some reason seems not to work as it should (and the error appeared to be thrown in random places not where the assertion was actually getting made)

I've added an error message to the `ok` call that was actually erroring so that next time I can at least look for the error and understand right away the issue:
![Screenshot 2023-08-11 at 22 31 26](https://github.com/GregBrimble/pages-e2e-tests/assets/61631103/0fe506c0-b1fd-48f6-9b65-6c038c76da00)

Since I was already at it I added messages to all the `ok` calls as those could really help avoiding some pain in the future (and I don't think there is any benefit in not adding proper error messages right?)
