### PR TITLE
replace the wranglerPagesDev stdio piping from 'data' to 'readable'

### DIFF
--- a/scripts/src/wranglerPagesDev.ts
+++ b/scripts/src/wranglerPagesDev.ts
@@ -53,15 +53,15 @@ export const wranglerPagesDev = async ({
 	wranglerProcess.stderr.on("readable", () => {
 		let chunk: any;
 		while (null !== (chunk = wranglerProcess.stderr.read())) {
-			const chunkStr: string = chunk.toString();
+			const chunkStr = chunk.toString();
 
 			logger.debug(chunkStr);
 
-			if (chunk.toString().includes("The Workers runtime failed to start")) {
+			if (chunkStr.includes("The Workers runtime failed to start")) {
 				logger.error(
 					"Error: Wrangler failed to start the dev server, aborting!"
 				);
-				wranglerProcess.kill("SIGTERM");
+				wranglerProcess.kill();
 			}
 		}
 	});

--- a/scripts/src/wranglerPagesDev.ts
+++ b/scripts/src/wranglerPagesDev.ts
@@ -43,12 +43,27 @@ export const wranglerPagesDev = async ({
 		},
 	});
 
-	wranglerProcess.stdout?.on("data", (chunk) => {
-		logger.debug(chunk.toString());
+	wranglerProcess.stdout.on("readable", () => {
+		let chunk: any;
+		while (null !== (chunk = wranglerProcess.stdout.read())) {
+			logger.debug(chunk.toString());
+		}
 	});
 
-	wranglerProcess.stderr?.on("data", (chunk) => {
-		logger.debug(chunk.toString());
+	wranglerProcess.stderr.on("readable", () => {
+		let chunk: any;
+		while (null !== (chunk = wranglerProcess.stderr.read())) {
+			const chunkStr: string = chunk.toString();
+
+			logger.debug(chunkStr);
+
+			if (chunk.toString().includes("The Workers runtime failed to start")) {
+				logger.error(
+					"Error: Wrangler failed to start the dev server, aborting!"
+				);
+				wranglerProcess.kill("SIGTERM");
+			}
+		}
 	});
 
 	return promise;


### PR DESCRIPTION
```ts
wranglerProcess.stderr?.on("data", (chunk) => {
  logger.debug(chunk.toString());
});
```
doesn't seem to be working 😕 

so I've replaced it with `on("readable",` which instead seems to be working as expected

With this we can get proper logging of errors from wrangler + I've added a check so that we can abort the process if the dev server has actually failed to start

___

After replacing `--port=0` to `--port=-1` with it:

This is what we get before the change:
![Screenshot 2023-08-14 at 12 37 42](https://github.com/GregBrimble/pages-e2e-tests/assets/61631103/3a04040e-5979-46aa-8ea7-722d960c933f)

(the process hangs indefinitely)

(this has been especially problematic on [next-on-pages workflows](https://github.com/cloudflare/next-on-pages/actions/runs/5826551602/job/15800756106#step:4:654) in which the tests take a long time to fail (as long they are allowed to run) and don't provide any info as to what has gone wrong)

This is what we get after the change:
![Screenshot 2023-08-14 at 12 30 27](https://github.com/GregBrimble/pages-e2e-tests/assets/61631103/976b66e6-40b9-45ef-b1d9-ccf1f3f4d95d)

___

PS: I've updated stdout for consistency (and I checked that it also wasn't logging anything)