### PR TITLE
make features setup optional

### DIFF
--- a/schemas/feature-schema.jsonc
+++ b/schemas/feature-schema.jsonc
@@ -361,9 +361,6 @@
       "description": "The additional deployment configuration to use when deploying this feature."
     }
   },
-  "required": [
-    "setup"
-  ],
   "additionalProperties": false,
   "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/scripts/src/schemas.ts
+++ b/scripts/src/schemas.ts
@@ -238,10 +238,14 @@ export const fixturesSchema = z
 export type FixtureConfig = z.TypeOf<typeof fixturesSchema>;
 
 export const featuresSchema = z.object({
-	setup: z
-		.string()
-		.nonempty()
-		.describe("The command to run to apply this feature to a fixture project."),
+	setup: z.optional(
+		z
+			.string()
+			.nonempty()
+			.describe(
+				"The command to run to apply this feature to a fixture project."
+			)
+	),
 	deploymentConfig: z
 		.object({
 			...combinableDeploymentConfigObjects,


### PR DESCRIPTION
It would be convenient if feature setup option could be optional (as the fixture's setup is)

I think that this might have been the plan anyways given this check:
https://github.com/GregBrimble/pages-e2e-tests/blob/c7735a480edcce532f4a7d488787361230ec2d4a/scripts/src/setUpFeatures.ts#L96