### PR TITLE
implement fixtures scoped features

### DIFF
--- a/scripts/src/setUpFeatures.ts
+++ b/scripts/src/setUpFeatures.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "fs";
-import { readFile } from "fs/promises";
+import { readFile, readdir } from "fs/promises";
 import { join } from "path";
 import shellac from "shellac";
 import stripJsonComments from "strip-json-comments";
@@ -35,6 +35,19 @@ export const setUpFeatures = async ({
 			queueProducers: {},
 		},
 	};
+
+	try {
+		const fixtureFeaturesDir = join(directory, "features");
+
+		const fixtureSpecificFeatures: Feature[] = (
+			await readdir(fixtureFeaturesDir)
+		).map((feature) => ({
+			name: feature,
+			path: join(fixtureFeaturesDir, feature),
+		}));
+
+		fixtureSpecificFeatures.forEach((feature) => features.push(feature));
+	} catch {}
 
 	if (features.length > 0) {
 		logger.log(


### PR DESCRIPTION
I am not completely set on the idea, but I think it could be handy to allow features to be defined inside fixtures themselves, for when a feature isn't meant to be reused and makes sense only within a specific fixture.

For example in the next-on-pages e2es, the [pages-issue-578 fixture](https://github.com/cloudflare/next-on-pages/tree/main/pages-e2e/fixtures/pages-issue-578) uses the [pages-issue-578 feature](https://github.com/cloudflare/next-on-pages/tree/main/pages-e2e/features/pages-issue-578), so it would be nicer if the feature could be included in the fixture itself (and that's what the changes here enable).

I think it's clear by the changes, anyways the idea is that in addition to the features defined in the fixture `main.fixture` file  also any feature present in a `features` directory within the fixture directory are also picked up and applied.

(Alternatively if more clear we could just allow fixtures to also include tests, but that might conflict with the fixtures/features mental model)